### PR TITLE
Use runtime environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# env file
+.env

--- a/cmd/dex-http-server/main.go
+++ b/cmd/dex-http-server/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"net/http"
+	"os"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"google.golang.org/grpc"
@@ -11,11 +12,32 @@ import (
 	"google.golang.org/grpc/grpclog"
 )
 
-var (
-	// command-line options:
-	// gRPC server endpoint
-	grpcServerEndpoint = flag.String("grpc-server-endpoint", "localhost:9090", "gRPC server endpoint")
-)
+func getEnv(key, fallback string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	return fallback
+}
+
+func run() error {
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Get gRPC server endpoint from environment variable at runtime
+	grpcServerEndpoint := getEnv("GRPC_SERVER_ENDPOINT", "localhost:5556")
+
+	// Register gRPC server endpoint
+	mux := runtime.NewServeMux()
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	err := gw.RegisterYourServiceHandlerFromEndpoint(ctx, mux, grpcServerEndpoint, opts)
+	if err != nil {
+		return err
+	}
+
+	// Start HTTP server (and proxy calls to gRPC server endpoint)
+	return http.ListenAndServe(":8080", mux)
+}
 
 func run() error {
 	ctx := context.Background()


### PR DESCRIPTION
[WIP] - does not work because of the following error:

```
# google.golang.org/grpc/internal/status
vendor/google.golang.org/grpc/internal/status/status.go:55:52: cannot use st (variable of type *"google.golang.org/genproto/googleapis/rpc/status".Status) as protoreflect.ProtoMessage value in argument to proto.Unmarshal: *"google.golang.org/genproto/googleapis/rpc/status".Status does not implement protoreflect.ProtoMessage (missing method ProtoReflect)
vendor/google.golang.org/grpc/internal/status/status.go:87:20: impossible type assertion: proto.Clone(s).(*spb.Status)
        *"google.golang.org/genproto/googleapis/rpc/status".Status does not implement protoreflect.ProtoMessage (missing method ProtoReflect)
```

This PR seeks to use env to determine location of grpc server as well as the port this server is served from. 

closes #1 
