### PR TITLE
Make api endpoints contingent on env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ buf generate
 
 3. Run the server
 
+> Before running, ensure that you have set the environment variables "GRPC_SERVER_ENDPOINT" and "HTTP_SERVER_PORT"
+
 ```bash
 go run cmd/dex-http-server/main.go
 ```

--- a/cmd/dex-http-server/main.go
+++ b/cmd/dex-http-server/main.go
@@ -1,23 +1,33 @@
 package main
 
 import (
+	"context"
 	"flag"
+	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"google.golang.org/grpc/grpclog"
 )
 
-var (
-	// command-line options:
-	// gRPC server endpoint
-	grpcServerEndpoint = flag.String("grpc-server-endpoint", "localhost:9090", "gRPC server endpoint")
-)
+func getEnv(key, fallback string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	return fallback
+}
 
 func run() error {
-	// ctx := context.Background()
-	// ctx, cancel := context.WithCancel(ctx)
-	// defer cancel()
+	ctx := context.Background()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	grpcServerEndpoint := getEnv("GRPC_SERVER_ENDPOINT", "localhost:9090")
+	fmt.Printf("\033[32m%s\033[0m\n", "gRPC server endpoint registered: "+grpcServerEndpoint)
+
+	httpServerPort := getEnv("HTTP_SERVER_PORT", "8081")
+	fmt.Printf("\033[32m%s\033[0m\n", "HTTP server listening on port: "+httpServerPort)
 
 	// Register gRPC server endpoint
 	// Note: Make sure the gRPC server is running properly and accessible
@@ -29,7 +39,7 @@ func run() error {
 	// }
 
 	// Start HTTP server (and proxy calls to gRPC server endpoint)
-	return http.ListenAndServe(":8081", mux)
+	return http.ListenAndServe(":"+httpServerPort, mux)
 }
 
 func main() {


### PR DESCRIPTION
Adds two environment variables which the server inspects at runtime. 

Closes #1