### PR TITLE
#9 Create environment used in docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
 FROM golang:1.23rc2-alpine3.20
 
+# Set environment variables
+ENV HTTP_SERVER_PORT 8080
+ENV GRPC_SERVER_ADDRESS dex:5557
+
+
 WORKDIR /app
 COPY . /app
 
 RUN go build -o bin/dex-http-server ./cmd/dex-http-server/main.go
 
-ENTRYPOINT ["/app/bin/dex-http-server"]
+ENTRYPOINT /app/bin/dex-http-server --http-port=${HTTP_SERVER_PORT} --grpc-server=${GRPC_SERVER_ADDRESS}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,9 @@ services:
   dex-http-server:
     restart: always
     container_name: dex-http-server
+    environment:
+      - HTTP_SERVER_PORT=8080
+      - GRPC_SERVER_ADDRESS=dex:5557
     depends_on:
       - dex
     build: .


### PR DESCRIPTION
Adds environment variables for http port and gRPC server endpoint. 

Closes #9 