### PR TITLE
[BOP-711] Add RESTfull endpoints for Dex API

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ can be found in the `api/api.pb.gq.go` file.
 protobuf compiler
 
 ```bash
+go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@v2.22.0
+go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@v2.22.0
 go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28
 go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
 ```

--- a/api/mapping.yaml
+++ b/api/mapping.yaml
@@ -1,0 +1,19 @@
+
+type: google.api.Service
+config_version: 3
+
+http:
+  rules:
+    - selector: api.Dex.CreatePassword
+      post: "/v1/users"
+      body: "*"
+    - selector: api.Dex.UpdatePassword
+      put: "/v1/users/{email}"
+      body: "*"
+    - selector: api.Dex.DeletePassword
+      delete: "/v1/users/{email}"
+    - selector: api.Dex.ListPasswords
+      get: "/v1/users"
+    - selector: api.Dex.VerifyPassword
+      post: "/v1/users/verify"
+      body: "*"

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -12,4 +12,9 @@ plugins:
     out: gen/go
     opt:
       - paths=source_relative
-      - generate_unbound_methods=true
+      - generate_unbound_methods=false
+      - grpc_api_configuration=api/mapping.yaml
+  - plugin: openapiv2
+    out: gen/openapiv2
+    opt:
+      - grpc_api_configuration=api/mapping.yaml

--- a/gen/go/api/api.pb.gw.go
+++ b/gen/go/api/api.pb.gw.go
@@ -31,84 +31,6 @@ var _ = runtime.String
 var _ = utilities.NewDoubleArray
 var _ = metadata.Join
 
-func request_Dex_CreateClient_0(ctx context.Context, marshaler runtime.Marshaler, client DexClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq CreateClientReq
-	var metadata runtime.ServerMetadata
-
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-
-	msg, err := client.CreateClient(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
-	return msg, metadata, err
-
-}
-
-func local_request_Dex_CreateClient_0(ctx context.Context, marshaler runtime.Marshaler, server DexServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq CreateClientReq
-	var metadata runtime.ServerMetadata
-
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-
-	msg, err := server.CreateClient(ctx, &protoReq)
-	return msg, metadata, err
-
-}
-
-func request_Dex_UpdateClient_0(ctx context.Context, marshaler runtime.Marshaler, client DexClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq UpdateClientReq
-	var metadata runtime.ServerMetadata
-
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-
-	msg, err := client.UpdateClient(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
-	return msg, metadata, err
-
-}
-
-func local_request_Dex_UpdateClient_0(ctx context.Context, marshaler runtime.Marshaler, server DexServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq UpdateClientReq
-	var metadata runtime.ServerMetadata
-
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-
-	msg, err := server.UpdateClient(ctx, &protoReq)
-	return msg, metadata, err
-
-}
-
-func request_Dex_DeleteClient_0(ctx context.Context, marshaler runtime.Marshaler, client DexClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq DeleteClientReq
-	var metadata runtime.ServerMetadata
-
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-
-	msg, err := client.DeleteClient(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
-	return msg, metadata, err
-
-}
-
-func local_request_Dex_DeleteClient_0(ctx context.Context, marshaler runtime.Marshaler, server DexServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq DeleteClientReq
-	var metadata runtime.ServerMetadata
-
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-
-	msg, err := server.DeleteClient(ctx, &protoReq)
-	return msg, metadata, err
-
-}
-
 func request_Dex_CreatePassword_0(ctx context.Context, marshaler runtime.Marshaler, client DexClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq CreatePasswordReq
 	var metadata runtime.ServerMetadata
@@ -143,6 +65,23 @@ func request_Dex_UpdatePassword_0(ctx context.Context, marshaler runtime.Marshal
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["email"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "email")
+	}
+
+	protoReq.Email, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "email", err)
+	}
+
 	msg, err := client.UpdatePassword(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 
@@ -156,6 +95,23 @@ func local_request_Dex_UpdatePassword_0(ctx context.Context, marshaler runtime.M
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["email"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "email")
+	}
+
+	protoReq.Email, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "email", err)
+	}
+
 	msg, err := server.UpdatePassword(ctx, &protoReq)
 	return msg, metadata, err
 
@@ -165,8 +121,21 @@ func request_Dex_DeletePassword_0(ctx context.Context, marshaler runtime.Marshal
 	var protoReq DeletePasswordReq
 	var metadata runtime.ServerMetadata
 
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["email"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "email")
+	}
+
+	protoReq.Email, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "email", err)
 	}
 
 	msg, err := client.DeletePassword(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
@@ -178,8 +147,21 @@ func local_request_Dex_DeletePassword_0(ctx context.Context, marshaler runtime.M
 	var protoReq DeletePasswordReq
 	var metadata runtime.ServerMetadata
 
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["email"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "email")
+	}
+
+	protoReq.Email, err = runtime.String(val)
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "email", err)
 	}
 
 	msg, err := server.DeletePassword(ctx, &protoReq)
@@ -191,10 +173,6 @@ func request_Dex_ListPasswords_0(ctx context.Context, marshaler runtime.Marshale
 	var protoReq ListPasswordReq
 	var metadata runtime.ServerMetadata
 
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-
 	msg, err := client.ListPasswords(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 
@@ -204,89 +182,7 @@ func local_request_Dex_ListPasswords_0(ctx context.Context, marshaler runtime.Ma
 	var protoReq ListPasswordReq
 	var metadata runtime.ServerMetadata
 
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-
 	msg, err := server.ListPasswords(ctx, &protoReq)
-	return msg, metadata, err
-
-}
-
-func request_Dex_GetVersion_0(ctx context.Context, marshaler runtime.Marshaler, client DexClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq VersionReq
-	var metadata runtime.ServerMetadata
-
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-
-	msg, err := client.GetVersion(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
-	return msg, metadata, err
-
-}
-
-func local_request_Dex_GetVersion_0(ctx context.Context, marshaler runtime.Marshaler, server DexServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq VersionReq
-	var metadata runtime.ServerMetadata
-
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-
-	msg, err := server.GetVersion(ctx, &protoReq)
-	return msg, metadata, err
-
-}
-
-func request_Dex_ListRefresh_0(ctx context.Context, marshaler runtime.Marshaler, client DexClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq ListRefreshReq
-	var metadata runtime.ServerMetadata
-
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-
-	msg, err := client.ListRefresh(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
-	return msg, metadata, err
-
-}
-
-func local_request_Dex_ListRefresh_0(ctx context.Context, marshaler runtime.Marshaler, server DexServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq ListRefreshReq
-	var metadata runtime.ServerMetadata
-
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-
-	msg, err := server.ListRefresh(ctx, &protoReq)
-	return msg, metadata, err
-
-}
-
-func request_Dex_RevokeRefresh_0(ctx context.Context, marshaler runtime.Marshaler, client DexClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq RevokeRefreshReq
-	var metadata runtime.ServerMetadata
-
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-
-	msg, err := client.RevokeRefresh(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
-	return msg, metadata, err
-
-}
-
-func local_request_Dex_RevokeRefresh_0(ctx context.Context, marshaler runtime.Marshaler, server DexServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq RevokeRefreshReq
-	var metadata runtime.ServerMetadata
-
-	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
-		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
-	}
-
-	msg, err := server.RevokeRefresh(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -324,81 +220,6 @@ func local_request_Dex_VerifyPassword_0(ctx context.Context, marshaler runtime.M
 // GRPC interceptors will not work for this type of registration. To use interceptors, you must use the "runtime.WithMiddlewares" option in the "runtime.NewServeMux" call.
 func RegisterDexHandlerServer(ctx context.Context, mux *runtime.ServeMux, server DexServer) error {
 
-	mux.Handle("POST", pattern_Dex_CreateClient_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		ctx, cancel := context.WithCancel(req.Context())
-		defer cancel()
-		var stream runtime.ServerTransportStream
-		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
-		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		var err error
-		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/api.Dex/CreateClient", runtime.WithHTTPPathPattern("/api.Dex/CreateClient"))
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		resp, md, err := local_request_Dex_CreateClient_0(annotatedContext, inboundMarshaler, server, req, pathParams)
-		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
-		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
-		if err != nil {
-			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
-			return
-		}
-
-		forward_Dex_CreateClient_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
-	})
-
-	mux.Handle("POST", pattern_Dex_UpdateClient_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		ctx, cancel := context.WithCancel(req.Context())
-		defer cancel()
-		var stream runtime.ServerTransportStream
-		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
-		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		var err error
-		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/api.Dex/UpdateClient", runtime.WithHTTPPathPattern("/api.Dex/UpdateClient"))
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		resp, md, err := local_request_Dex_UpdateClient_0(annotatedContext, inboundMarshaler, server, req, pathParams)
-		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
-		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
-		if err != nil {
-			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
-			return
-		}
-
-		forward_Dex_UpdateClient_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
-	})
-
-	mux.Handle("POST", pattern_Dex_DeleteClient_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		ctx, cancel := context.WithCancel(req.Context())
-		defer cancel()
-		var stream runtime.ServerTransportStream
-		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
-		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		var err error
-		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/api.Dex/DeleteClient", runtime.WithHTTPPathPattern("/api.Dex/DeleteClient"))
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		resp, md, err := local_request_Dex_DeleteClient_0(annotatedContext, inboundMarshaler, server, req, pathParams)
-		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
-		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
-		if err != nil {
-			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
-			return
-		}
-
-		forward_Dex_DeleteClient_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
-	})
-
 	mux.Handle("POST", pattern_Dex_CreatePassword_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -407,7 +228,7 @@ func RegisterDexHandlerServer(ctx context.Context, mux *runtime.ServeMux, server
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/api.Dex/CreatePassword", runtime.WithHTTPPathPattern("/api.Dex/CreatePassword"))
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/api.Dex/CreatePassword", runtime.WithHTTPPathPattern("/v1/users"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -424,7 +245,7 @@ func RegisterDexHandlerServer(ctx context.Context, mux *runtime.ServeMux, server
 
 	})
 
-	mux.Handle("POST", pattern_Dex_UpdatePassword_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle("PUT", pattern_Dex_UpdatePassword_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
@@ -432,7 +253,7 @@ func RegisterDexHandlerServer(ctx context.Context, mux *runtime.ServeMux, server
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/api.Dex/UpdatePassword", runtime.WithHTTPPathPattern("/api.Dex/UpdatePassword"))
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/api.Dex/UpdatePassword", runtime.WithHTTPPathPattern("/v1/users/{email}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -449,7 +270,7 @@ func RegisterDexHandlerServer(ctx context.Context, mux *runtime.ServeMux, server
 
 	})
 
-	mux.Handle("POST", pattern_Dex_DeletePassword_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle("DELETE", pattern_Dex_DeletePassword_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
@@ -457,7 +278,7 @@ func RegisterDexHandlerServer(ctx context.Context, mux *runtime.ServeMux, server
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/api.Dex/DeletePassword", runtime.WithHTTPPathPattern("/api.Dex/DeletePassword"))
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/api.Dex/DeletePassword", runtime.WithHTTPPathPattern("/v1/users/{email}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -474,7 +295,7 @@ func RegisterDexHandlerServer(ctx context.Context, mux *runtime.ServeMux, server
 
 	})
 
-	mux.Handle("POST", pattern_Dex_ListPasswords_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle("GET", pattern_Dex_ListPasswords_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
@@ -482,7 +303,7 @@ func RegisterDexHandlerServer(ctx context.Context, mux *runtime.ServeMux, server
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/api.Dex/ListPasswords", runtime.WithHTTPPathPattern("/api.Dex/ListPasswords"))
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/api.Dex/ListPasswords", runtime.WithHTTPPathPattern("/v1/users"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -499,81 +320,6 @@ func RegisterDexHandlerServer(ctx context.Context, mux *runtime.ServeMux, server
 
 	})
 
-	mux.Handle("POST", pattern_Dex_GetVersion_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		ctx, cancel := context.WithCancel(req.Context())
-		defer cancel()
-		var stream runtime.ServerTransportStream
-		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
-		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		var err error
-		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/api.Dex/GetVersion", runtime.WithHTTPPathPattern("/api.Dex/GetVersion"))
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		resp, md, err := local_request_Dex_GetVersion_0(annotatedContext, inboundMarshaler, server, req, pathParams)
-		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
-		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
-		if err != nil {
-			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
-			return
-		}
-
-		forward_Dex_GetVersion_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
-	})
-
-	mux.Handle("POST", pattern_Dex_ListRefresh_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		ctx, cancel := context.WithCancel(req.Context())
-		defer cancel()
-		var stream runtime.ServerTransportStream
-		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
-		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		var err error
-		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/api.Dex/ListRefresh", runtime.WithHTTPPathPattern("/api.Dex/ListRefresh"))
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		resp, md, err := local_request_Dex_ListRefresh_0(annotatedContext, inboundMarshaler, server, req, pathParams)
-		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
-		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
-		if err != nil {
-			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
-			return
-		}
-
-		forward_Dex_ListRefresh_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
-	})
-
-	mux.Handle("POST", pattern_Dex_RevokeRefresh_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		ctx, cancel := context.WithCancel(req.Context())
-		defer cancel()
-		var stream runtime.ServerTransportStream
-		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
-		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		var err error
-		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/api.Dex/RevokeRefresh", runtime.WithHTTPPathPattern("/api.Dex/RevokeRefresh"))
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		resp, md, err := local_request_Dex_RevokeRefresh_0(annotatedContext, inboundMarshaler, server, req, pathParams)
-		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
-		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
-		if err != nil {
-			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
-			return
-		}
-
-		forward_Dex_RevokeRefresh_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
-	})
-
 	mux.Handle("POST", pattern_Dex_VerifyPassword_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -582,7 +328,7 @@ func RegisterDexHandlerServer(ctx context.Context, mux *runtime.ServeMux, server
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/api.Dex/VerifyPassword", runtime.WithHTTPPathPattern("/api.Dex/VerifyPassword"))
+		annotatedContext, err = runtime.AnnotateIncomingContext(ctx, mux, req, "/api.Dex/VerifyPassword", runtime.WithHTTPPathPattern("/v1/users/verify"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -640,79 +386,13 @@ func RegisterDexHandler(ctx context.Context, mux *runtime.ServeMux, conn *grpc.C
 // "DexClient" to call the correct interceptors. This client ignores the HTTP middlewares.
 func RegisterDexHandlerClient(ctx context.Context, mux *runtime.ServeMux, client DexClient) error {
 
-	mux.Handle("POST", pattern_Dex_CreateClient_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		ctx, cancel := context.WithCancel(req.Context())
-		defer cancel()
-		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		var err error
-		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/api.Dex/CreateClient", runtime.WithHTTPPathPattern("/api.Dex/CreateClient"))
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		resp, md, err := request_Dex_CreateClient_0(annotatedContext, inboundMarshaler, client, req, pathParams)
-		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
-		if err != nil {
-			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
-			return
-		}
-
-		forward_Dex_CreateClient_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
-	})
-
-	mux.Handle("POST", pattern_Dex_UpdateClient_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		ctx, cancel := context.WithCancel(req.Context())
-		defer cancel()
-		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		var err error
-		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/api.Dex/UpdateClient", runtime.WithHTTPPathPattern("/api.Dex/UpdateClient"))
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		resp, md, err := request_Dex_UpdateClient_0(annotatedContext, inboundMarshaler, client, req, pathParams)
-		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
-		if err != nil {
-			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
-			return
-		}
-
-		forward_Dex_UpdateClient_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
-	})
-
-	mux.Handle("POST", pattern_Dex_DeleteClient_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		ctx, cancel := context.WithCancel(req.Context())
-		defer cancel()
-		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		var err error
-		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/api.Dex/DeleteClient", runtime.WithHTTPPathPattern("/api.Dex/DeleteClient"))
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		resp, md, err := request_Dex_DeleteClient_0(annotatedContext, inboundMarshaler, client, req, pathParams)
-		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
-		if err != nil {
-			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
-			return
-		}
-
-		forward_Dex_DeleteClient_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
-	})
-
 	mux.Handle("POST", pattern_Dex_CreatePassword_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/api.Dex/CreatePassword", runtime.WithHTTPPathPattern("/api.Dex/CreatePassword"))
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/api.Dex/CreatePassword", runtime.WithHTTPPathPattern("/v1/users"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -728,13 +408,13 @@ func RegisterDexHandlerClient(ctx context.Context, mux *runtime.ServeMux, client
 
 	})
 
-	mux.Handle("POST", pattern_Dex_UpdatePassword_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle("PUT", pattern_Dex_UpdatePassword_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/api.Dex/UpdatePassword", runtime.WithHTTPPathPattern("/api.Dex/UpdatePassword"))
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/api.Dex/UpdatePassword", runtime.WithHTTPPathPattern("/v1/users/{email}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -750,13 +430,13 @@ func RegisterDexHandlerClient(ctx context.Context, mux *runtime.ServeMux, client
 
 	})
 
-	mux.Handle("POST", pattern_Dex_DeletePassword_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle("DELETE", pattern_Dex_DeletePassword_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/api.Dex/DeletePassword", runtime.WithHTTPPathPattern("/api.Dex/DeletePassword"))
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/api.Dex/DeletePassword", runtime.WithHTTPPathPattern("/v1/users/{email}"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -772,13 +452,13 @@ func RegisterDexHandlerClient(ctx context.Context, mux *runtime.ServeMux, client
 
 	})
 
-	mux.Handle("POST", pattern_Dex_ListPasswords_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle("GET", pattern_Dex_ListPasswords_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/api.Dex/ListPasswords", runtime.WithHTTPPathPattern("/api.Dex/ListPasswords"))
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/api.Dex/ListPasswords", runtime.WithHTTPPathPattern("/v1/users"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -794,79 +474,13 @@ func RegisterDexHandlerClient(ctx context.Context, mux *runtime.ServeMux, client
 
 	})
 
-	mux.Handle("POST", pattern_Dex_GetVersion_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		ctx, cancel := context.WithCancel(req.Context())
-		defer cancel()
-		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		var err error
-		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/api.Dex/GetVersion", runtime.WithHTTPPathPattern("/api.Dex/GetVersion"))
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		resp, md, err := request_Dex_GetVersion_0(annotatedContext, inboundMarshaler, client, req, pathParams)
-		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
-		if err != nil {
-			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
-			return
-		}
-
-		forward_Dex_GetVersion_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
-	})
-
-	mux.Handle("POST", pattern_Dex_ListRefresh_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		ctx, cancel := context.WithCancel(req.Context())
-		defer cancel()
-		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		var err error
-		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/api.Dex/ListRefresh", runtime.WithHTTPPathPattern("/api.Dex/ListRefresh"))
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		resp, md, err := request_Dex_ListRefresh_0(annotatedContext, inboundMarshaler, client, req, pathParams)
-		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
-		if err != nil {
-			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
-			return
-		}
-
-		forward_Dex_ListRefresh_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
-	})
-
-	mux.Handle("POST", pattern_Dex_RevokeRefresh_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
-		ctx, cancel := context.WithCancel(req.Context())
-		defer cancel()
-		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
-		var err error
-		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/api.Dex/RevokeRefresh", runtime.WithHTTPPathPattern("/api.Dex/RevokeRefresh"))
-		if err != nil {
-			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
-			return
-		}
-		resp, md, err := request_Dex_RevokeRefresh_0(annotatedContext, inboundMarshaler, client, req, pathParams)
-		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
-		if err != nil {
-			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
-			return
-		}
-
-		forward_Dex_RevokeRefresh_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
-
-	})
-
 	mux.Handle("POST", pattern_Dex_VerifyPassword_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
 		var err error
 		var annotatedContext context.Context
-		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/api.Dex/VerifyPassword", runtime.WithHTTPPathPattern("/api.Dex/VerifyPassword"))
+		annotatedContext, err = runtime.AnnotateContext(ctx, mux, req, "/api.Dex/VerifyPassword", runtime.WithHTTPPathPattern("/v1/users/verify"))
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
@@ -886,36 +500,18 @@ func RegisterDexHandlerClient(ctx context.Context, mux *runtime.ServeMux, client
 }
 
 var (
-	pattern_Dex_CreateClient_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"api.Dex", "CreateClient"}, ""))
+	pattern_Dex_CreatePassword_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "users"}, ""))
 
-	pattern_Dex_UpdateClient_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"api.Dex", "UpdateClient"}, ""))
+	pattern_Dex_UpdatePassword_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "users", "email"}, ""))
 
-	pattern_Dex_DeleteClient_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"api.Dex", "DeleteClient"}, ""))
+	pattern_Dex_DeletePassword_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 1, 0, 4, 1, 5, 2}, []string{"v1", "users", "email"}, ""))
 
-	pattern_Dex_CreatePassword_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"api.Dex", "CreatePassword"}, ""))
+	pattern_Dex_ListPasswords_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"v1", "users"}, ""))
 
-	pattern_Dex_UpdatePassword_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"api.Dex", "UpdatePassword"}, ""))
-
-	pattern_Dex_DeletePassword_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"api.Dex", "DeletePassword"}, ""))
-
-	pattern_Dex_ListPasswords_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"api.Dex", "ListPasswords"}, ""))
-
-	pattern_Dex_GetVersion_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"api.Dex", "GetVersion"}, ""))
-
-	pattern_Dex_ListRefresh_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"api.Dex", "ListRefresh"}, ""))
-
-	pattern_Dex_RevokeRefresh_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"api.Dex", "RevokeRefresh"}, ""))
-
-	pattern_Dex_VerifyPassword_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1}, []string{"api.Dex", "VerifyPassword"}, ""))
+	pattern_Dex_VerifyPassword_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "users", "verify"}, ""))
 )
 
 var (
-	forward_Dex_CreateClient_0 = runtime.ForwardResponseMessage
-
-	forward_Dex_UpdateClient_0 = runtime.ForwardResponseMessage
-
-	forward_Dex_DeleteClient_0 = runtime.ForwardResponseMessage
-
 	forward_Dex_CreatePassword_0 = runtime.ForwardResponseMessage
 
 	forward_Dex_UpdatePassword_0 = runtime.ForwardResponseMessage
@@ -923,12 +519,6 @@ var (
 	forward_Dex_DeletePassword_0 = runtime.ForwardResponseMessage
 
 	forward_Dex_ListPasswords_0 = runtime.ForwardResponseMessage
-
-	forward_Dex_GetVersion_0 = runtime.ForwardResponseMessage
-
-	forward_Dex_ListRefresh_0 = runtime.ForwardResponseMessage
-
-	forward_Dex_RevokeRefresh_0 = runtime.ForwardResponseMessage
 
 	forward_Dex_VerifyPassword_0 = runtime.ForwardResponseMessage
 )

--- a/gen/openapiv2/api/api.swagger.json
+++ b/gen/openapiv2/api/api.swagger.json
@@ -1,0 +1,433 @@
+  {
+  "swagger": "2.0",
+  "info": {
+    "title": "api/api.proto",
+    "version": "version not set"
+  },
+  "tags": [
+    {
+      "name": "Dex"
+    }
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/v1/users": {
+      "get": {
+        "summary": "ListPassword lists all password entries.",
+        "operationId": "Dex_ListPasswords",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiListPasswordResp"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "tags": [
+          "Dex"
+        ]
+      },
+      "post": {
+        "summary": "CreatePassword creates a password.",
+        "operationId": "Dex_CreatePassword",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiCreatePasswordResp"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "description": "CreatePasswordReq is a request to make a password.",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiCreatePasswordReq"
+            }
+          }
+        ],
+        "tags": [
+          "Dex"
+        ]
+      }
+    },
+    "/v1/users/verify": {
+      "post": {
+        "summary": "VerifyPassword returns whether a password matches a hash for a specific email or not.",
+        "operationId": "Dex_VerifyPassword",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiVerifyPasswordResp"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/apiVerifyPasswordReq"
+            }
+          }
+        ],
+        "tags": [
+          "Dex"
+        ]
+      }
+    },
+    "/v1/users/{email}": {
+      "delete": {
+        "summary": "DeletePassword deletes the password.",
+        "operationId": "Dex_DeletePassword",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiDeletePasswordResp"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "email",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "tags": [
+          "Dex"
+        ]
+      },
+      "put": {
+        "summary": "UpdatePassword modifies existing password.",
+        "operationId": "Dex_UpdatePassword",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/apiUpdatePasswordResp"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "email",
+            "description": "The email used to lookup the password. This field cannot be modified",
+            "in": "path",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/DexUpdatePasswordBody"
+            }
+          }
+        ],
+        "tags": [
+          "Dex"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "DexUpdatePasswordBody": {
+      "type": "object",
+      "properties": {
+        "newHash": {
+          "type": "string",
+          "format": "byte"
+        },
+        "newUsername": {
+          "type": "string"
+        }
+      },
+      "description": "UpdatePasswordReq is a request to modify an existing password."
+    },
+    "apiClient": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "secret": {
+          "type": "string"
+        },
+        "redirectUris": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "trustedPeers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "public": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "logoUrl": {
+          "type": "string"
+        }
+      },
+      "description": "Client represents an OAuth2 client."
+    },
+    "apiCreateClientResp": {
+      "type": "object",
+      "properties": {
+        "alreadyExists": {
+          "type": "boolean"
+        },
+        "client": {
+          "$ref": "#/definitions/apiClient"
+        }
+      },
+      "description": "CreateClientResp returns the response from creating a client."
+    },
+    "apiCreatePasswordReq": {
+      "type": "object",
+      "properties": {
+        "password": {
+          "$ref": "#/definitions/apiPassword"
+        }
+      },
+      "description": "CreatePasswordReq is a request to make a password."
+    },
+    "apiCreatePasswordResp": {
+      "type": "object",
+      "properties": {
+        "alreadyExists": {
+          "type": "boolean"
+        }
+      },
+      "description": "CreatePasswordResp returns the response from creating a password."
+    },
+    "apiDeleteClientResp": {
+      "type": "object",
+      "properties": {
+        "notFound": {
+          "type": "boolean"
+        }
+      },
+      "description": "DeleteClientResp determines if the client is deleted successfully."
+    },
+    "apiDeletePasswordResp": {
+      "type": "object",
+      "properties": {
+        "notFound": {
+          "type": "boolean"
+        }
+      },
+      "description": "DeletePasswordResp returns the response from deleting a password."
+    },
+    "apiListPasswordResp": {
+      "type": "object",
+      "properties": {
+        "passwords": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiPassword"
+          }
+        }
+      },
+      "description": "ListPasswordResp returns a list of passwords."
+    },
+    "apiListRefreshResp": {
+      "type": "object",
+      "properties": {
+        "refreshTokens": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/apiRefreshTokenRef"
+          }
+        }
+      },
+      "description": "ListRefreshResp returns a list of refresh tokens for a user."
+    },
+    "apiPassword": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "hash": {
+          "type": "string",
+          "format": "byte",
+          "description": "Currently we do not accept plain text passwords. Could be an option in the future."
+        },
+        "username": {
+          "type": "string"
+        },
+        "userId": {
+          "type": "string"
+        }
+      },
+      "description": "Password is an email for password mapping managed by the storage."
+    },
+    "apiRefreshTokenRef": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "ID of the refresh token."
+        },
+        "clientId": {
+          "type": "string"
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "int64"
+        },
+        "lastUsed": {
+          "type": "string",
+          "format": "int64"
+        }
+      },
+      "description": "RefreshTokenRef contains the metadata for a refresh token that is managed by the storage."
+    },
+    "apiRevokeRefreshResp": {
+      "type": "object",
+      "properties": {
+        "notFound": {
+          "type": "boolean",
+          "description": "Set to true is refresh token was not found and token could not be revoked."
+        }
+      },
+      "description": "RevokeRefreshResp determines if the refresh token is revoked successfully."
+    },
+    "apiUpdateClientResp": {
+      "type": "object",
+      "properties": {
+        "notFound": {
+          "type": "boolean"
+        }
+      },
+      "description": "UpdateClientResp returns the response from updating a client."
+    },
+    "apiUpdatePasswordResp": {
+      "type": "object",
+      "properties": {
+        "notFound": {
+          "type": "boolean"
+        }
+      },
+      "description": "UpdatePasswordResp returns the response from modifying an existing password."
+    },
+    "apiVerifyPasswordReq": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string"
+        },
+        "password": {
+          "type": "string"
+        }
+      }
+    },
+    "apiVerifyPasswordResp": {
+      "type": "object",
+      "properties": {
+        "verified": {
+          "type": "boolean"
+        },
+        "notFound": {
+          "type": "boolean"
+        }
+      }
+    },
+    "apiVersionResp": {
+      "type": "object",
+      "properties": {
+        "server": {
+          "type": "string",
+          "description": "Semantic version of the server."
+        },
+        "api": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Numeric version of the API. It increases every time a new call is added to the API.\nClients should use this info to determine if the server supports specific features."
+        }
+      },
+      "description": "VersionResp holds the version info of components."
+    },
+    "protobufAny": {
+      "type": "object",
+      "properties": {
+        "@type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": {}
+    },
+    "rpcStatus": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "message": {
+          "type": "string"
+        },
+        "details": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "$ref": "#/definitions/protobufAny"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds expose only the required RESTfull endpoints:

| Endpoints | Description |
|--------|--------|
| `GET /passwords` | lists all password entries |
|`POST /passwords` | creates a password |
| `POST /passwords/verify` | returns whether a password matches a hash for a specific email or not |
|`DELETE /passwords/{email}` | deletes the password |
|`PUT /passwords/{email}` | modifies existing password |

It also now generates OpenAPIV2 specs at: [gen/openapiv2/api/api.swagger.json](https://github.com/nwneisen/dex-http-server/pull/21/files#diff-902f2460bc7acc34990ac960fe53331a540d5a6798f228eb43dfab90ad41ac2d)

## Testing

Run local server using:
```
make up
```

#### Create a password
```
curl -X POST 'http://localhost:8080/passwords' \
 --header 'Content-Type: application/json' \
 --data-raw '
 {
   "password": {
     "email": "newuser1@example.com",
     "hash": "JDJhJDEyJDhNQmxXdWNiWG40bloxcjlXR0ovQS5FdFVmSnhHY3E3Z2prZmh6c2RDaTd1RGRNWDNCSmpL",
     "username": "newuser1",
     "userId": "15bbcd67-1e6f-45db-b34f-566b253a8220"
   }
 }'
```
```
{
  "alreadyExists": false
}
```

#### List passwords
```
curl --location 'http://localhost:8080/passwords'
```
```
{
  "passwords": [
    {
      "email": "newuser1@example.com",
      "hash": "",
      "username": "newuser1",
      "userId": "15bbcd67-1e6f-45db-b34f-566b253a8220"
    },
    {
      "email": "admin@example.com",
      "hash": "",
      "username": "admin",
      "userId": "08a8684b-db88-4b73-90a9-3cd1661f5466"
    }
  ]
}
```

#### Update a password
```
curl -X PUT 'http://localhost:8080/passwords/newuser1@example.com' \
--header 'Content-Type: application/json' \
--data '
{
    "new_hash": "JDJhJDEyJGppOUpPQ2lROUl2N2EwczVVZFk5NmU1ZnhoQTJIQ213ZTFaUWszYmd0ektSbmNLN0lvLmlL"
}'
```
```
{
  "notFound": false
}
```

#### Delete a password
```
curl -X DELETE 'http://localhost:8080/passwords/newuser1@example.com'  
```
```
{
  "notFound": false
}
```